### PR TITLE
Add minimal docs about configuring via profile

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,27 @@ $ $sado run /bin/echo "I'm a bad command!"
 I'm a bad command!
 ```
 
+## Managing Sado via MDM
+Sado uses the bundle identifier to look up the configuration, which defaults to com.facebook.cpe.Sado. You con enforce values for this with a configuration profile with the PayloadType that matches the bundle identifier (com.facebook.cpe.Sado).
+```xml
+  <key>PayloadContent</key>
+  <dict>
+    <key>ValidCommands</key>
+    <dict>
+      <key>run_true</key>
+      <array>
+        <string>/usr/bin/true</string>
+      </array>
+      <key>run_echo</key>
+      <array>
+        <string>/bin/echo</string>
+        <string>hello</string>
+        <string>there!</string>
+      </array>
+    </dict>
+  </dict>
+```
+
 ## Requirements
 Sado requires macOS 11.0 or later.
 


### PR DESCRIPTION
Added some minimal documentation to the README.md file about configuring Sado via a profile. TLDR:
'ProfileType': 'Configuration',
'ProfileItems': [
	'PayloadType': com.facebook.cpe.Sado,
	'PayloadContent': {
	    'ValidCommands': {
		'short_name': [ 'args', 'to', 'execve' ],
	    }
	}
]

Should resolve issue #6 